### PR TITLE
greater book

### DIFF
--- a/.github/workflows/pretext-cli.yml
+++ b/.github/workflows/pretext-cli.yml
@@ -60,7 +60,7 @@ jobs:
     deploy-ghpages:
         runs-on: ubuntu-latest
         needs: build
-        if: vars.PTX_ENABLE_DEPLOY_GHPAGES == 'yes'
+        if: vars.PTX_ENABLE_DEPLOY_GHPAGES == 'yes' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         permissions:
             contents: read
             pages: write

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -5,7 +5,7 @@
   <xi:include href="./docinfo.ptx" />
 
   <book xml:id="my-great-book">
-    <title>My Great Book</title>
+    <title>My Greater Book</title>
     <subtitle>An example to get you started</subtitle>
 
     <!-- Include frontmatter -->


### PR DESCRIPTION
Before opening this PR, I set a repository variable `PTX_ENABLE_DEPLOY_GHPAGES` to `yes`. But the ghpages deploy should not occur since we're on a branch. It should instead only occur once the branch is merged to main.

(There were a couple of failures below fixed by [dbc316b](https://github.com/StevenClontz/silver-doodle/pull/1/commits/dbc316bb54b4289be7be4f4e7fda0e1ea1bc38d7). The Cloudflare thing can be ignored as well.)